### PR TITLE
Datastorage table char encoding updated 

### DIFF
--- a/src/SandraCore/SandraDatabaseDefinition.php
+++ b/src/SandraCore/SandraDatabaseDefinition.php
@@ -68,7 +68,7 @@ class SandraDatabaseDefinition
         $sql = "CREATE TABLE IF NOT EXISTS `$tablestorage` 
                 (
                     `linkReferenced` int(11) NOT NULL,
-                    `value` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+                    `value` mediumtext CHARACTER SET utf8mb4 NOT NULL,
                 PRIMARY KEY (`linkReferenced`)
                 ) 
                 ENGINE=MyISAM 


### PR DESCRIPTION
Current encoding for datastorage table is utf8 that does not support range of special characters, in order to support more characters it is upgraded to use utf8mb4 with default collation. 

This change will allow the tables to be created during env setup to have updated change. 

Impact and comments - 
- With 4bytes per character it increases storage and hence reducing performance.
- Considering this is a special table not heavily used. So the performance factor can be ignored. 